### PR TITLE
Adjustments for Roland VersaWorks

### DIFF
--- a/src/contourer.js
+++ b/src/contourer.js
@@ -306,7 +306,7 @@ class Contourer {
 
   /**
    * @async
-   * Append encoded image to the end of SVG body
+   * Insert encoded image at the beginning of SVG body
    */
   async mergeSvgAndEncodedBitmapImage() {
     await log.info('Merge SVG and encoded image');
@@ -324,10 +324,16 @@ class Contourer {
     let imageTag = `<image width="${this.size.width}" height="${this.size.height}" xlink:href="${this.encodedImage}" />`;
 
     /**
-     * Add image tag at the end of SVG body
+     * Fix path stroke width
      * @type {string}
      */
-    result = result.replace('</svg>', `${imageTag}</svg>`);
+    result = result.replace('<path ', '<path stroke-width="0.25" ');
+
+    /**
+     * Add image tag just before path
+     * @type {string}
+     */
+    result = result.replace('<path', `${imageTag}\n<path`);
 
     this.resultSVG = result;
   }


### PR DESCRIPTION
- Render contour last (i.e. make it the frontmost object)
- Make the stroke thinner.  Unclear what the units are here, but I'm going for 0.25pt, and this seems to be close enough.

Unfortunately, there's no way to do custom spot colors in SVG.  So, that has to be patched in after conversion to EPS:

```
%%DocumentCustomColors: (CutContour)
%%CMYKCustomColor: 0 1 0 0 (CutContour)
0 1 0 0 (CutContour) findcmykcustomcolor 1 setcustomcolor
```